### PR TITLE
rename trace to debug

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.8.0
+
+- rename log's `trace` to `debug`
+  ([#12](https://github.com/feltjs/util/pull/12))
+
 ## 0.7.5
 
 - fix root exports to omit modules with Node dependencies

--- a/src/lib/log.test.ts
+++ b/src/lib/log.test.ts
@@ -12,7 +12,7 @@ const createTest__loggerContext = (): TestLoggerContext => {
 	const ctx: TestLoggerContext = {
 		loggedArgs: undefined, // stores the result of the latest log call
 		loggerState: {
-			level: 'trace',
+			level: 'debug',
 			log: (...logArgs: any[]) => {
 				ctx.loggedArgs = logArgs;
 			},
@@ -30,9 +30,9 @@ const createTest__loggerContext = (): TestLoggerContext => {
 				prefixes: ['infoP1', 'infoP2'],
 				suffixes: ['infoS1', 'infoS2'],
 			},
-			trace: {
-				prefixes: ['traceP1', 'traceP2'],
-				suffixes: ['traceS1', 'traceS2'],
+			debug: {
+				prefixes: ['debugP1', 'debugP2'],
+				suffixes: ['debugS1', 'debugS2'],
 			},
 		},
 	};
@@ -94,19 +94,19 @@ test__Logger('prefixes and suffixes', (ctx) => {
 	]);
 	ctx.loggedArgs = undefined;
 
-	log.trace('foo', 36);
+	log.debug('foo', 36);
 	assert.equal(ctx.loggedArgs, [
 		'pre',
-		'traceP1',
-		'traceP2',
+		'debugP1',
+		'debugP2',
 		'p1',
 		'p2',
 		'foo',
 		36,
 		's1',
 		's2',
-		'traceS1',
-		'traceS2',
+		'debugS1',
+		'debugS2',
 		'post',
 	]);
 	ctx.loggedArgs = undefined;

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -4,14 +4,14 @@ import {EMPTY_ARRAY, toArray} from './array.js';
 
 // TODO could use some refactoring
 
-export type LogLevel = 'off' | 'error' | 'warn' | 'info' | 'trace';
+export type LogLevel = 'off' | 'error' | 'warn' | 'info' | 'debug';
 
 const LOG_LEVEL_VALUES: Record<LogLevel, number> = {
 	off: 0,
 	error: 1,
 	warn: 2,
 	info: 3,
-	trace: 4,
+	debug: 4,
 };
 
 export const toLogLevelValue = (level: LogLevel): number => LOG_LEVEL_VALUES[level] ?? 4;
@@ -88,7 +88,7 @@ export interface LoggerState extends LogLevelDefaults {
 	error: LogLevelDefaults;
 	warn: LogLevelDefaults;
 	info: LogLevelDefaults;
-	trace: LogLevelDefaults;
+	debug: LogLevelDefaults;
 }
 
 interface LogLevelDefaults {
@@ -152,16 +152,16 @@ export class BaseLogger {
 		);
 	}
 
-	trace(...args: unknown[]): void {
-		if (!shouldLog(this.state.level, 'trace')) return;
+	debug(...args: unknown[]): void {
+		if (!shouldLog(this.state.level, 'debug')) return;
 		this.state.log(
 			...resolveValues(
 				this.state.prefixes,
-				this.state.trace.prefixes,
+				this.state.debug.prefixes,
 				this.prefixes,
 				args,
 				this.suffixes,
-				this.state.trace.suffixes,
+				this.state.debug.suffixes,
 				this.state.suffixes,
 			),
 		);
@@ -214,7 +214,7 @@ export class Logger extends BaseLogger {
 		prefixes: [gray('➤')],
 		suffixes: [],
 	};
-	static trace: LogLevelDefaults = {
+	static debug: LogLevelDefaults = {
 		prefixes: [gray('—')],
 		suffixes: [],
 	};
@@ -250,7 +250,7 @@ export class SystemLogger extends BaseLogger {
 	static error = Logger.error;
 	static warn = Logger.warn;
 	static info = Logger.info;
-	static trace = Logger.trace;
+	static debug = Logger.debug;
 }
 
 export const printLogLabel = (label: string, color = magenta): string =>

--- a/src/lib/print.ts
+++ b/src/lib/print.ts
@@ -47,6 +47,6 @@ export const printTiming = (key: string | number, timing: number): string =>
 
 export const printTimings = (timings: Timings, log: Logger): void => {
 	for (const [key, timing] of timings.getAll()) {
-		log.trace(printTiming(key, timing));
+		log.debug(printTiming(key, timing));
 	}
 };

--- a/src/lib/process.ts
+++ b/src/lib/process.ts
@@ -90,7 +90,7 @@ export const registerGlobalSpawn = (child: ChildProcess): (() => void) => {
 export const despawn = (child: ChildProcess): Promise<SpawnResult> => {
 	let resolve: (v: SpawnResult) => void;
 	const closed = new Promise<SpawnResult>((r) => (resolve = r));
-	log.trace('despawning', printChildProcess(child));
+	log.debug('despawning', printChildProcess(child));
 	child.once('close', (code, signal) => {
 		resolve(code ? {ok: false, code, signal} : {ok: true, signal});
 	});


### PR DESCRIPTION
`log.debug` is a more common convention than `log.trace`, and it's now less confusing since we don't do the behavior of `console.trace` with the stack trace